### PR TITLE
Added armv6 as target platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Help Options:
 Docker image
 ---
 
-A recent docker image (multiarch amd64,arm/v7) is automatically built for each release at sfudeus/dht22-exporter:$TAG.
+A recent docker image (multiarch amd64,arm/v7,arm/v6) is automatically built for each release at sfudeus/dht22-exporter:$TAG.

--- a/build.sh
+++ b/build.sh
@@ -15,9 +15,9 @@ IMAGE_VERSION=${PRG_VERSION}_${GO_VERSION}
 IMAGE_REPO=sfudeus/dht22-exporter
 
 echo "Building version $IMAGE_VERSION"
-docker buildx build --build-arg "GO_VERSION=${GO_VERSION}" --platform linux/amd64 --platform linux/arm/v7 -t "${IMAGE_REPO}:${IMAGE_VERSION}" .
+docker buildx build --build-arg "GO_VERSION=${GO_VERSION}" --platform linux/amd64 --platform linux/arm/v7 --platform linux/arm/v6 -t "${IMAGE_REPO}:${IMAGE_VERSION}" .
 
 if [[ "${PUSH}" == "--push" ]]; then
   echo "Pushing version $IMAGE_VERSION"
-  docker buildx build --build-arg "GO_VERSION=${GO_VERSION}" --platform linux/amd64 --platform linux/arm/v7 -t "${IMAGE_REPO}:${IMAGE_VERSION}" .
+  docker buildx build --push --build-arg "GO_VERSION=${GO_VERSION}" --platform linux/amd64 --platform linux/arm/v7 --platform linux/arm/v6 -t "${IMAGE_REPO}:${IMAGE_VERSION}" .
 fi


### PR DESCRIPTION
I've successfully tested the armv6 docker image on the Raspberry Pi Zero W on Raspbian Buster.

This commit also adds the `--push` flag in the "push" section of build.sh.
I don't know how you managed to push images before since the two docker calls are identical. Maybe I'm missing something